### PR TITLE
Fix cannot set wallpaper on mate-desktop

### DIFF
--- a/bing_wallpaper.sh
+++ b/bing_wallpaper.sh
@@ -206,8 +206,8 @@ while true; do
       DISPLAY=:0 GSETTINGS_BACKEND=dconf gsettings set org.gnome.desktop.background picture-options $picOpts
     fi
 
-    if [[ $DE = "gnome3" ]]; then
-    gsettings set org.gnome.desktop.background picture-uri '"file://'$saveDir$picName'"'
+    if [[ $DE = "mate" ]]; then
+      dconf write /org/mate/desktop/background/picture-filename \"$saveDir$picName\"
     fi
 
     if [[ $DE = "kde" ]]; then


### PR DESCRIPTION
Fix cannot set wallpaper on mate-desktop. Tested on mate-desktop only.
