### PR TITLE
Add lxde case

### DIFF
--- a/bing-wallpaper.go
+++ b/bing-wallpaper.go
@@ -241,6 +241,11 @@ func set_wallpaper(de, pic string) {
     check(err)
   }
 
+  if de == "lxde" {
+    _, err := exec.Command("/usr/bin/pcmanfm", "-w", pic).Output()
+    check(err)
+  }
+
   if de == "lxqt" {
     _, err := exec.Command("/usr/bin/pcmanfm-qt", "-w", pic).Output()
     check(err)


### PR DESCRIPTION
Simple change to add lxde to the list of DEs, as it is already detected. LXDE uses pcmanfm to manage the desktop, not pcmanfm-qt. As it is, if the script determines the user is running lxde, it doesn't do anything.