### PR TITLE
Fix dconf write for mate

### DIFF
--- a/bing-wallpaper.go
+++ b/bing-wallpaper.go
@@ -315,7 +315,7 @@ func setWallpaper(env, pic, picOpts string) {
 		_, err = exec.Command("/usr/bin/gsettings", "set", "com.deepin.wrap.gnome.desktop.background", "picture-options", picOpts).Output()
 		errChk(err)
 	case "mate":
-		_, err := exec.Command("/usr/bin/dconf", "write", "/org/mate/desktop/background/picture-filename", pic).Output()
+		_, err := exec.Command("/usr/bin/dconf", "write", "/org/mate/desktop/background/picture-filename", fmt.Sprintf("'%s'", pic)).Output()
 		errChk(err)
 	case "lxde":
 		_, err := exec.Command("/usr/bin/pcmanfm", "-w", pic).Output()


### PR DESCRIPTION
As per dconf docs:

`VALUE arguments must be in GVariant format, so e.g. a string must include explicit quotes: "'foo'".`
https://developer.gnome.org/dconf/unstable/dconf-tool.html

otherwise you see error:
```
$ ./bing-wallpaper -market=en-US
started bing-wallpaper
upstream uri:http://bing.com/az/hprichbg/rb/MardiGrasIndians_EN-US7436694464_1920x1200.jpg
upstream uri:http://bing.com/az/hprichbg/rb/MardiGrasIndians_EN-US7436694464_1920x1080.jpg
downloaded to:/home/ubuntu/Pictures/Bing/MardiGrasIndians_EN-US7436694464_1920x1080.jpg
setting wallpaper for mate
panic: exit status 1

goroutine 1 [running]:
main.errChk(0x6de2e0, 0xc42000c660)
	/home/ubuntu/.local/bin/linux-bing-wallpaper/bing-wallpaper.go:28 +0x4a
main.setWallpaper(0x6abdae, 0x4, 0xc42001e230, 0x49, 0x6abe0e, 0x4)
	/home/ubuntu/.local/bin/linux-bing-wallpaper/bing-wallpaper.go:319 +0x4d2
main.main()
	/home/ubuntu/.local/bin/linux-bing-wallpaper/bing-wallpaper.go:467 +0x7ef
```

Note that two other things weren't working for me in MATE:
1) It was incorrectly being detected as gnome and trying to run gsettings
2) dbusChk was throwing an error so I commented it out (might be due to the fact that I was remoting in via RDP)

```
bing-wallpaper 
started bing-wallpaper
setting DBUS_SESSION_BUS_ADDRESS
panic: runtime error: index out of range

goroutine 1 [running]:
main.dbusChk()
	/home/ubuntu/.local/bin/linux-bing-wallpaper/bing-wallpaper.go:278 +0x267
main.main()
	/home/ubuntu/.local/bin/linux-bing-wallpaper/bing-wallpaper.go:461 +0x35d

```
