### PR TITLE
issues-34 feh use bg-fill instead bg-tile

### DIFF
--- a/bing-wallpaper.go
+++ b/bing-wallpaper.go
@@ -335,7 +335,7 @@ func setWallpaper(env, pic, picOpts string) {
 		setPlasmaWallpaper(pic)
 	default:
 		// other netWM/EWMH window manager
-		_, err := exec.Command("/usr/bin/feh", "--bg-tile", pic).Output()
+		_, err := exec.Command("/usr/bin/feh", "--bg-fill", pic).Output()
 		errChk(err)
 	}
 }


### PR DESCRIPTION
https://github.com/marguerite/linux-bing-wallpaper/issues/34

options ```bg-fill``` more adaptable in different resolutions or according to the aspect ratio of the monitor