### PR TITLE
Don't panic because of unneded dependencies in KDE5

### DIFF
--- a/bing-wallpaper.go
+++ b/bing-wallpaper.go
@@ -422,7 +422,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "desktop",
-			Usage: "Specify your destkop environment",
+			Usage: "Specify your desktop environment",
 		},
 		cli.StringFlag{
 			Name:  "dir, d",

--- a/bing-wallpaper.go
+++ b/bing-wallpaper.go
@@ -229,16 +229,6 @@ func setWallpaper(desktop, pic, opts, cmd string) {
 }
 
 func setPlasmaWallpaper(pic, env string) {
-	if _, err := exec.Search("/usr/bin/xdotool"); err != nil {
-		panic("please install xdotool")
-	}
-	if _, err := exec.Search("/usr/bin/gettext"); err != nil {
-		panic("please install gettext-runtime")
-	}
-
-	lang, _ := exec.Env("LANG")
-	lang = strings.Split(lang, ".")[0]
-	console := "Desktop Shell Scripting Console"
 	var window, suffix, script string
 	prefix := filepath.Join("/home", os.Getenv("LOGNAME"), ".local/share/plasmashell")
 	dir.MkdirP(prefix)
@@ -246,6 +236,17 @@ func setPlasmaWallpaper(pic, env string) {
 
 	switch env {
 	case "kde4":
+		if _, err := exec.Search("/usr/bin/xdotool"); err != nil {
+			panic("please install xdotool")
+		}
+		if _, err := exec.Search("/usr/bin/gettext"); err != nil {
+			panic("please install gettext-runtime")
+		}
+	
+		lang, _ := exec.Env("LANG")
+		lang = strings.Split(lang, ".")[0]
+		console := "Desktop Shell Scripting Console"
+
 		suffix = "Plasma Desktop Shell"
 		window = console + " - " + suffix
 		if len(lang) > 0 {


### PR DESCRIPTION
Even though `/usr/bin/xdotool` and `/usr/bin/gettext` are not required for KDE5, `linux-bing-wallpaper` still fails with an error if these programs are not available.
I just moved this requirement check down into the `kde4` path. Works perfectly fine on my machine now.